### PR TITLE
Add scores to properties from googleapi

### DIFF
--- a/src/witan/gwyn/gwyn.clj
+++ b/src/witan/gwyn/gwyn.clj
@@ -138,7 +138,7 @@
                   (merge map-key
                          {:num-fires n
                           :avg-pumps-attending
-                          (u/average n coll-pumps-attending)
+                          (u/average coll-pumps-attending)
                           :sd-pumps-attending (wst/standard-deviation
                                                coll-pumps-attending)}))))
         ds/dataset)})
@@ -193,7 +193,7 @@
                          (wds/subset-ds :cols :generic-fire-risk-score))
                     types)
         clean-scores (filter #(instance? Number %) scores)]
-    (u/average (count clean-scores) clean-scores)))
+    (u/average clean-scores)))
 
 (defworkflowfn associate-risk-score-to-commercial-properties-1-0-0
   {:witan/name :fire-risk/associate-risk-score-to-commercial-properties

--- a/src/witan/gwyn/gwyn.clj
+++ b/src/witan/gwyn/gwyn.clj
@@ -5,6 +5,7 @@
             [schema.core :as s]
             [witan.gwyn.schemas :as sc]
             [clojure.core.matrix.dataset :as ds]
+            [clojure.core.matrix :as mx]
             [witan.datasets :as wds]
             [witan.datasets.stats :as wst]
             [witan.gwyn.utils :as u]
@@ -131,14 +132,13 @@
   {:commercial-properties-by-type
    (->> (wds/group-ds lfb-historic-incidents :property-type)
         (mapv (fn [[map-key ds]]
-                (let [n (first (:shape ds))
-                      avg (fn [coll] (u/safe-divide (apply + coll) n))
+                (let [n (mx/row-count ds)
                       coll-pumps-attending (u/make-coll
                                             (wds/subset-ds ds :cols :num-pumps-attending))]
                   (merge map-key
                          {:num-fires n
                           :avg-pumps-attending
-                          (avg coll-pumps-attending)
+                          (u/average n coll-pumps-attending)
                           :sd-pumps-attending (wst/standard-deviation
                                                coll-pumps-attending)}))))
         ds/dataset)})
@@ -166,7 +166,7 @@
   "Takes in the properties dataset sorted by pumps and fires.
    Use the sorting order to assign a score to each property type."
   [sorted-properties-data]
-  (let [range-data (range 1 (-> sorted-properties-data :shape first inc))]
+  (let [range-data (range 1 (-> sorted-properties-data mx/row-count inc))]
     (-> sorted-properties-data
         (ds/add-column :generic-fire-risk-score range-data)
         (ds/select-columns [:property-type :generic-fire-risk-score]))))
@@ -185,6 +185,16 @@
                            sort-by-pumps-and-fires
                            assign-generic-scores)})
 
+(defn lookup-score
+  [lookup-ds types]
+  (let [scores (map #(-> lookup-ds
+                         (wds/select-from-ds {:google-property-type
+                                              {:eq %}})
+                         (wds/subset-ds :cols :generic-fire-risk-score))
+                    types)
+        clean-scores (filter #(instance? Number %) scores)]
+    (u/average (count clean-scores) clean-scores)))
+
 (defworkflowfn associate-risk-score-to-commercial-properties-1-0-0
   {:witan/name :fire-risk/associate-risk-score-to-commercial-properties
    :witan/version "1.0.0"
@@ -194,13 +204,15 @@
    :witan/output-schema {:commercial-properties-with-scores sc/CommercialPropertiesWithScores}}
   [{:keys [generic-fire-risks commercial-properties property-comparison]} _]
   {:commercial-properties-with-scores
-   (let [n (-> commercial-properties
-               :shape
-               first)
-         risk-score 1.0] ;;;; to be replaced with joining
+   (let [comparison-scores (wds/join (ds/rename-columns generic-fire-risks
+                                                        {:property-type :lfb-property-type})
+                                     property-comparison
+                                     [:lfb-property-type])]
      (-> commercial-properties
-         (ds/add-column :risk-score (repeat n risk-score))
-         (ds/add-column :date-last-risk-assessed (repeat n nil))
+         (wds/add-derived-column :risk-score
+                                 [:type] (fn [t] (lookup-score comparison-scores t)))
+         (ds/add-column :date-last-risk-assessed (repeat (mx/row-count commercial-properties)
+                                                         nil))
          (ds/select-columns [:address :name :risk-score :date-last-risk-assessed])))})
 
 (defworkflowfn join-historical-and-new-scores-1-0-0

--- a/src/witan/gwyn/schemas.clj
+++ b/src/witan/gwyn/schemas.clj
@@ -30,10 +30,6 @@
   (make-ordered-ds-schema [[:property-type s/Str]
                            [:num-pumps-attending s/Int]]))
 
-(def HistoricalFireRiskScores
-  (make-ordered-ds-schema [[:address s/Str] [:name s/Str] [:risk-score java.lang.Double]
-                           [:date-last-risk-assessed (s/maybe sc/Date)]]))
-
 (def FireStationGeoData
   (make-ordered-ds-schema [[:radius java.lang.Double] [:lat java.lang.Double]
                            [:long java.lang.Double]]))

--- a/src/witan/gwyn/utils.clj
+++ b/src/witan/gwyn/utils.clj
@@ -13,5 +13,5 @@
     (/ ^double d dd)))
 
 (defn average
-  [x xs]
-  (safe-divide (apply + xs) x))
+  [xs]
+  (safe-divide (apply + xs) (count xs)))

--- a/src/witan/gwyn/utils.clj
+++ b/src/witan/gwyn/utils.clj
@@ -11,3 +11,7 @@
   (if (zero? dd)
     0.0
     (/ ^double d dd)))
+
+(defn average
+  [x xs]
+  (safe-divide (apply + xs) x))

--- a/test/witan/gwyn/acceptance/workspace_test.clj
+++ b/test/witan/gwyn/acceptance/workspace_test.clj
@@ -35,5 +35,6 @@
                          :contracts (p/available-fns (m/model-library))}
           workspace'    (s/with-fn-validation (wex/build! workspace))
           result        (apply merge (wex/run!! workspace' {}))]
+      (println result)
       (is result)
       (is (:new-fire-risk-scores result)))))

--- a/test/witan/gwyn/gwyn_test.clj
+++ b/test/witan/gwyn/gwyn_test.clj
@@ -115,13 +115,16 @@
 
 (deftest associate-risk-score-to-commercial-properties-test
   (testing "function returns properties with added cols :risk-score & :date-last-risk-assessed"
-    (let [result (reduce (fn [acc func] (merge acc (func acc)))
+    (let [input-map (reduce (fn [acc func] (merge acc (func acc)))
                          test-data
                          [group-commercial-properties-type-1-0-0
                           generic-commercial-properties-fire-risk-1-0-0
-                          list-commercial-properties-1-0-0
-                          associate-risk-score-to-commercial-properties-1-0-0])
+                          list-commercial-properties-1-0-0])
+          result (associate-risk-score-to-commercial-properties-1-0-0 input-map)
           result-data (:commercial-properties-with-scores result)]
+      (println result-data)
       (is (ds/dataset? result-data))
       (is (= (set (:column-names result-data))
-             #{:address :name :risk-score :date-last-risk-assessed})))))
+             #{:address :name :risk-score :date-last-risk-assessed}))
+      (is (not-empty (wds/subset-ds result-data :cols :risk-score)))
+      (is (every? nil? (wds/subset-ds result-data :cols :date-last-risk-assessed))))))

--- a/test/witan/gwyn/gwyn_test.clj
+++ b/test/witan/gwyn/gwyn_test.clj
@@ -36,7 +36,7 @@
     (let [result (extract-fire-station-geo-data-1-0-0 test-data {:fire-station "Twickenham"})
           result-data (:fire-station-geo-data result)]
       (is (ds/dataset? result-data))
-      (is (= (second result-data)) 3)
+      (is (= (second (:shape result-data)) 3))
       (is (= (set (:column-names result-data))
              #{:radius :lat :long})))))
 
@@ -116,13 +116,12 @@
 (deftest associate-risk-score-to-commercial-properties-test
   (testing "function returns properties with added cols :risk-score & :date-last-risk-assessed"
     (let [input-map (reduce (fn [acc func] (merge acc (func acc)))
-                         test-data
-                         [group-commercial-properties-type-1-0-0
-                          generic-commercial-properties-fire-risk-1-0-0
-                          list-commercial-properties-1-0-0])
+                            test-data
+                            [group-commercial-properties-type-1-0-0
+                             generic-commercial-properties-fire-risk-1-0-0
+                             list-commercial-properties-1-0-0])
           result (associate-risk-score-to-commercial-properties-1-0-0 input-map)
           result-data (:commercial-properties-with-scores result)]
-      (println result-data)
       (is (ds/dataset? result-data))
       (is (= (set (:column-names result-data))
              #{:address :name :risk-score :date-last-risk-assessed}))


### PR DESCRIPTION
Associate or calculate scores for actual commercial properties

* create a lookup dataset by joining the property types comparison input (LFB vs googleapi types) with the generic scores dataset
* add a `:risk-score` column to the commercial properties dataset (results from googleapi call)
* for each set of types, calculate the score by averaging the scores of all types in the set
* note: a googleapi type can correspond to several LFB types and thus to several scores -> here too, the scores are averaged