### PR TITLE
Fix weird property risk scores

### DIFF
--- a/data/lfb_to_google.csv
+++ b/data/lfb_to_google.csv
@@ -114,3 +114,13 @@ Rugby Stadium ,stadium
 Local Government Office,local_government_office
 Theatre ,movie_theater
 Electrical warehouse ,electronics_store
+Single shop ,bicycle_store
+Other outdoor sporting venue ,campground
+Vehicle Repair Workshop,car_wash
+Other outdoor sporting venue ,cemetery
+Other private non-residential building ,lodging
+Other outdoor sporting venue ,park
+Other car park structure,rv_park
+Other outdoor sporting venue ,rv_park
+Other transport building ,taxi_stand
+Large supermarket ,store

--- a/src/witan/gwyn/gwyn.clj
+++ b/src/witan/gwyn/gwyn.clj
@@ -81,11 +81,11 @@
     "administrative_area_level_3" "administrative_area_level_4"
     "administrative_area_level_5" "colloquial_area"
     "country" "establishment" "finance" "floor" "food"
-    "general_contractor" "geocode" "health" "intersection"
-    "locality" "natural_feature" "neighborhood" "place_of_worship"
-    "political" "point_of_interest" "post_box" "postal_code"
-    "postal_code_prefix" "postal_code_suffix" "postal_town"
-    "premise" "room" "route" "street_address" "street_number"
+    "general_contractor" "grocery_or_supermarket" "geocode"
+    "health" "intersection" "locality" "natural_feature"
+    "neighborhood" "place_of_worship" "political" "point_of_interest"
+    "post_box" "postal_code" "postal_code_prefix" "postal_code_suffix"
+    "postal_town" "premise" "room" "route" "street_address" "street_number"
     "sublocality" "sublocality_level_4" "sublocality_level_5"
     "sublocality_level_3" "sublocality_level_2"
     "sublocality_level_1" "subpremise"})
@@ -191,9 +191,8 @@
                          (wds/select-from-ds {:google-property-type
                                               {:eq %}})
                          (wds/subset-ds :cols :generic-fire-risk-score))
-                    types)
-        clean-scores (filter #(instance? Number %) scores)]
-    (u/average clean-scores)))
+                    types)]
+    (u/average (flatten scores))))
 
 (defworkflowfn associate-risk-score-to-commercial-properties-1-0-0
   {:witan/name :fire-risk/associate-risk-score-to-commercial-properties


### PR DESCRIPTION
There were quite a few scores equal to `0.0` due to different things:

* property types were missing from the set of types to be deprecated
* a few property types didn't have a match in the lfb-googleapi lookup table
* the case in which one google api type matches two lfb types wasn't taken into account and returned and empty list

I tried this fix for a few different fire stations and it seems OK.